### PR TITLE
TODO-007: Schedule a job to reset "complete" tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem "rack-cors"
 
+gem "rufus-scheduler"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,11 @@ GEM
     diff-lcs (1.5.0)
     digest (3.1.0)
     erubi (1.10.0)
+    et-orbi (1.2.6)
+      tzinfo
+    fugit (1.5.2)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.4)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.8.11)
@@ -138,6 +143,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-cors (1.1.1)
@@ -193,6 +199,8 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.10.3)
     rubyzip (2.3.2)
+    rufus-scheduler (3.8.1)
+      fugit (~> 1.1, >= 1.1.6)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -245,6 +253,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.0.1)
   rspec-rails
+  rufus-scheduler
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,8 +5,11 @@ class Task < ApplicationRecord
 
     scheduler = Rufus::Scheduler.new
 
-    scheduler.every '300s' do
-        Task.all.each { |task_obj| task_obj.update(is_completed: false) if task_obj.is_completed == true} 
+    def self.update_task
+        Task.where('is_completed = ?', true).update_all(is_completed: false )
     end
 
+    scheduler.every '300s' do
+        update_task 
+    end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,11 @@ class Task < ApplicationRecord
 
     belongs_to :user
     validates :description, presence: true
+
+    scheduler = Rufus::Scheduler.new
+
+    scheduler.every '300s' do
+        Task.all.each { |task_obj| task_obj.update(is_completed: false) if task_obj.is_completed == true} 
+    end
+
 end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TasksController, type: :controller do
     user_object = {
         first_name: "TestFirstName", 
         last_name: "TestLastName", 
-        email:"TestEmail",
+        email: "TestEmail",
         username: "TestUsername",
         password: "TestPassword",
         password_confirmation: "TestPassword"

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -2,13 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
 
+    user_object = {
+        first_name: "FirstName", 
+        last_name: "LastName", 
+        email: "Email",
+        username: "Username",
+        password: "Password",
+        password_confirmation: "Password"
+    }
+
     it "checks if a task can be created" do
-        user = User.create(first_name: "FirstName", 
-            last_name: "LastName", 
-            email: "Email",
-            username: "Username",
-            password: "Password",
-            password_confirmation: "Password")
+        user = User.create(user_object)
         task = Task.create(description: "walk the dog", user_id: user.id)
 
         expect(task).to be_valid
@@ -32,4 +36,12 @@ RSpec.describe Task, type: :model do
         expect(task.is_completed).to be false
     end
 
+    it "will update task.is_completed from true to false" do
+        user = User.create(user_object)
+        task = Task.create(description: "walk the dog", user_id: user.id)
+        task.update(is_completed: true)
+        Task.update_task
+
+        expect(Task.all[0].is_completed).to be false
+    end
 end


### PR DESCRIPTION
Now every 5 minutes  any true values of task's "is_completed"  attribute will be reset to false.

1. Pull the branch and start the server - bin/rails s

2. Signup:
 Open Postman and make a POST request to localhost:3000/users with request body: 
        {"user": {"first_name": "Anna", "last_name": "Doe", "email": "ana_doe@Yahoo.com", "username": "ana_doe", "password": "ana1234", "password_confirmation": "ana1234"}}

3. Verify that the response is : "A new account was successfully created!"

4. Add a task: make a POST request to localhost:3000/ tasks with request body {"description": "test task"}
 
5. Verify that the response is : "The task was successfully created."

6. Update a task: make a POST request to localhost:3000/tasks/1 with request body {"is_completed": true}

7. Verify that the response is: "The task was successfully updated."

8. Make a GET request to localhost:3000/tasks and verify if the response is:{
        "id": 1,
        "description": "test task",
        "is_completed": true,
        "created_at": "2022-02-04T17:33:27.697Z",
        "updated_at": "2022-02-04T17:33:27.697Z",
        "user_id": 1
    }

9. After 5 minutes make a GET request to localhost:3000/tasks and verify if the response is: {
        "id": 1,
        "description": "test task",
        "is_completed": false,
        "created_at": "2022-02-04T17:33:27.697Z",
        "updated_at": "2022-02-04T17:33:27.697Z",
        "user_id": 1
    }
